### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/controllers/sdb/index.ts
+++ b/src/controllers/sdb/index.ts
@@ -25,7 +25,7 @@ type OwnerVerificationResult = "verified" | "mismatch" | "needs-claim";
 
 function defaultDBName() {
   const username = process.env.USER || process.env.USERNAME || "user";
-  console.warn("No database name was configured. Using the default username-based database name instead:", `${username}-test`);
+  console.warn("No database name was configured. Using a default username-based database name.");
   return `${username}-test`;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Incoverse/Waiter/security/code-scanning/3](https://github.com/Incoverse/Waiter/security/code-scanning/3)

To fix this safely without changing functionality, keep the fallback DB-name behavior unchanged but stop logging the username-derived value. In `src/controllers/sdb/index.ts`, update `defaultDBName()` so the warning message is generic and does not include `` `${username}-test` `` (or `username`) in clear text.

Best single fix:
- Keep:
  - `const username = process.env.USER || process.env.USERNAME || "user";`
  - `return `${username}-test`;`
- Change only the `console.warn(...)` on line 28 to a static message that does not interpolate sensitive/environment-derived content.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
