### PR TITLE
C:/Program Files/Git/schedule + /link commands, trigger cloning, interception effect wiring

### DIFF
--- a/src/controllers/dashboard/app/app/(dashboard)/obs/page.tsx
+++ b/src/controllers/dashboard/app/app/(dashboard)/obs/page.tsx
@@ -57,6 +57,7 @@ import {
   SkipForward,
   ChevronDown,
   ChevronRight,
+  Download,
 } from "lucide-react";
 
 /* ───────────────────────── types ───────────────────────── */
@@ -447,6 +448,7 @@ export default function ObsPage() {
               <StatsCard stats={status!.stats} />
               <HotkeysCard wuid={wuid} obs={obs} say={say} />
               <CaptionCard obs={obs} say={say} />
+              <ExportConfigCard wuid={wuid} />
             </>
           )}
         </>
@@ -456,6 +458,69 @@ export default function ObsPage() {
 }
 
 /* ───────────────────────── shared bits ───────────────────────── */
+
+// Dev-only: download this machine's OBS scene collections + profiles as a zip (stream key + auth
+// tokens are stripped server-side by the export route before it ever leaves the machine).
+function ExportConfigCard({ wuid }: { wuid: string }) {
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ text: string; kind: Kind } | null>(null);
+  const run = async () => {
+    if (!wuid) return;
+    setBusy(true);
+    setMsg(null);
+    try {
+      const r = await fetch("/dashboard/api/obs/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ wuid }),
+      });
+      if (!r.ok) {
+        const e = await r.json().catch(() => ({}));
+        setMsg({ text: e?.error ?? `Export failed (${r.status})`, kind: "err" });
+        return;
+      }
+      const blob = await r.blob();
+      const cd = r.headers.get("Content-Disposition") ?? "";
+      const fn = /filename="([^"]+)"/.exec(cd)?.[1] ?? "obs-config.zip";
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fn;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setMsg({ text: `Downloaded ${fn}`, kind: "ok" });
+    } catch (e: any) {
+      setMsg({ text: e?.message ?? "Export failed", kind: "err" });
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="section-card">
+      <div className="section-header">
+        <h3 className="section-title flex items-center gap-2">
+          <Download size={15} /> Export config
+        </h3>
+      </div>
+      <div className="section-body flex flex-col gap-2">
+        <p className="text-sm text-fg-subtle">
+          Download this machine&apos;s OBS scene collections + profiles as a .zip. The stream key and auth
+          tokens are excluded — they never leave the machine.
+        </p>
+        <button onClick={run} disabled={busy || !wuid} className="btn-primary text-sm w-fit">
+          <Download size={14} /> {busy ? "Exporting…" : "Export OBS config (.zip)"}
+        </button>
+        {msg && (
+          <span className="text-xs" style={{ color: msg.kind === "err" ? "var(--color-danger)" : "var(--color-success)" }}>
+            {msg.text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function FeedbackLine({ msg, kind }: { msg: string; kind: Kind }) {
   const color =

--- a/src/controllers/dashboard/app/app/(dashboard)/triggers/page.tsx
+++ b/src/controllers/dashboard/app/app/(dashboard)/triggers/page.tsx
@@ -17,6 +17,7 @@ import {
   Clock,
   Lock,
   Star,
+  Copy,
 } from "lucide-react";
 import { useActiveChannel } from "@/components/ActiveChannelProvider";
 
@@ -205,7 +206,7 @@ type PresetEntry = {
 const api = (path: string) => `/dashboard/api${path}`;
 
 export default function TriggersPage() {
-  const { activeChannelId, activeChannel, isOwnChannel, loading: channelLoading } =
+  const { activeChannelId, activeChannel, channels, isOwnChannel, loading: channelLoading } =
     useActiveChannel();
 
   const [isDev, setIsDev] = useState(false);
@@ -226,6 +227,9 @@ export default function TriggersPage() {
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const [editingCodeId, setEditingCodeId] = useState<string | null>(null);
   const [editingCmdId, setEditingCmdId] = useState<string | null>(null);
+  // Which row (if any) has its "clone to other channel" picker open, and the chosen target.
+  const [cloningUserId, setCloningUserId] = useState<string | null>(null);
+  const [cloneTarget, setCloneTarget] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggleExpand = (key: string) =>
     setExpanded((prev) => {
@@ -235,6 +239,12 @@ export default function TriggersPage() {
     });
 
   const canEdit = !!(activeChannel?.isBroadcaster || isDev);
+
+  // Channels this trigger could be cloned INTO: everything switchable except the current one,
+  // and only where the user could create a trigger (broadcaster, or dev anywhere).
+  const cloneTargets = canEdit
+    ? channels.filter((c) => c.id !== activeChannelId && (c.isBroadcaster || isDev))
+    : [];
 
   useEffect(() => {
     fetch(api("/me"))
@@ -422,6 +432,34 @@ export default function TriggersPage() {
       }
     } catch {
       setUserTriggers((prev) => prev.map((u) => (u.id === t.id ? { ...u, [field]: t[field] } : u)));
+      flash("✗ Network error");
+    }
+    setToggling(null);
+  };
+
+  // --- Clone a user trigger onto another channel ---
+  // The clone creates a NEW managed reward on the target, so only managed triggers qualify: a
+  // mode:"existing" trigger points at a reward id that only exists on the source channel.
+  const cloneUserTrigger = async (t: UserTrigger, target: string) => {
+    if (!canEdit || toggling || !target) return;
+    const key = `clone:${t.id}`;
+    setToggling(key);
+    try {
+      const r = await fetch(api("/triggers/clone"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from: activeChannelId, to: target, id: t.id }),
+      });
+      const d = await r.json();
+      if (!d.success) {
+        flash(`✗ ${d.error ?? "Clone failed"}`);
+      } else {
+        const label = channels.find((c) => c.id === target)?.displayName ?? target;
+        flash(`✓ Cloned ${t.name} → ${label}`);
+        setCloningUserId(null);
+        setCloneTarget("");
+      }
+    } catch {
       flash("✗ Network error");
     }
     setToggling(null);
@@ -807,6 +845,35 @@ export default function TriggersPage() {
                                     title="Edit trigger"
                                     onClick={() => setEditingUserId((cur) => (cur === t.id ? null : t.id))}
                                   />
+                                  {cloneTargets.length > 0 && (
+                                    <button
+                                      onClick={() => {
+                                        setCloneTarget("");
+                                        setCloningUserId((cur) => (cur === t.id ? null : t.id));
+                                      }}
+                                      disabled={!t.manage_reward || toggling === `clone:${t.id}`}
+                                      title={
+                                        t.manage_reward
+                                          ? "Clone to another channel"
+                                          : "Only Waiter-managed rewards can be cloned — this trigger is linked to an existing reward on this channel"
+                                      }
+                                      className="inline-flex items-center text-xs transition-colors px-2 py-1 rounded-md border disabled:opacity-40 disabled:cursor-not-allowed"
+                                      style={{
+                                        color:
+                                          cloningUserId === t.id ? "var(--color-brand)" : "var(--color-fg-subtle)",
+                                        borderColor:
+                                          cloningUserId === t.id
+                                            ? "color-mix(in srgb, var(--color-brand) 30%, transparent)"
+                                            : "transparent",
+                                        background:
+                                          cloningUserId === t.id
+                                            ? "color-mix(in srgb, var(--color-brand) 10%, transparent)"
+                                            : "transparent",
+                                      }}
+                                    >
+                                      {cloningUserId === t.id ? <X size={12} /> : <Copy size={12} />}
+                                    </button>
+                                  )}
                                   <button
                                     onClick={() => deleteUserTrigger(t)}
                                     disabled={toggling === `del:${t.id}`}
@@ -820,6 +887,42 @@ export default function TriggersPage() {
                             </div>
                           </td>
                         </tr>
+                        {cloningUserId === t.id ? (
+                          <tr className="border-t border-line/50 bg-elevated/10">
+                            <td colSpan={3} className="px-5 py-4 pl-12">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className="text-xs text-fg-subtle">Clone to</span>
+                                <select
+                                  value={cloneTarget}
+                                  onChange={(e) => setCloneTarget(e.target.value)}
+                                  className="bg-elevated border border-line rounded-md px-2 py-1 text-xs"
+                                >
+                                  <option value="">Select a channel…</option>
+                                  {cloneTargets.map((c) => (
+                                    <option key={c.id} value={c.id}>
+                                      {c.displayName}
+                                    </option>
+                                  ))}
+                                </select>
+                                <button
+                                  onClick={() => cloneUserTrigger(t, cloneTarget)}
+                                  disabled={!cloneTarget || toggling === `clone:${t.id}`}
+                                  className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-md border border-line hover:bg-elevated transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                  <Copy size={12} />
+                                  {toggling === `clone:${t.id}` ? "Cloning…" : "Clone"}
+                                </button>
+                              </div>
+                              <p className="mt-2 text-[11px] text-fg-subtle">
+                                Creates a new channel-point reward on the target channel using this
+                                trigger&apos;s settings, plus its own trigger row. This channel is left
+                                untouched. If the target has its own script/preset of the same name, the
+                                clone binds to that one; otherwise it keeps a copy of this trigger&apos;s
+                                compiled steps.
+                              </p>
+                            </td>
+                          </tr>
+                        ) : null}
                         {editingUserId === t.id ? (
                           <tr className="border-t border-line/50 bg-elevated/10">
                             <td colSpan={3} className="px-5 py-4 pl-12">

--- a/src/controllers/dashboard/app/app/api/interception/route.ts
+++ b/src/controllers/dashboard/app/app/api/interception/route.ts
@@ -110,6 +110,20 @@ export async function POST(req: NextRequest) {
           angleDeg: Number(data.angleDeg),
         });
         break;
+      case "sensitivitySet":
+        //? `scale` sets both axes; scaleX/scaleY override per-axis. The client clamps to [0.05, 20].
+        result = await client.interceptionSensitivitySet({
+          enabled: data.enabled === true,
+          scaleX: Number(data.scaleX ?? data.scale),
+          scaleY: Number(data.scaleY ?? data.scale),
+        });
+        break;
+      case "typosSet":
+        result = await client.interceptionTyposSet({
+          enabled: data.enabled === true,
+          chance: Number(data.chance),
+        });
+        break;
       case "scriptRun": {
         // Server-side interpreter (supports loop/chance/ranges). Fire-and-forget; stop via scriptStop.
         const steps = Array.isArray(data.steps) ? data.steps : [];

--- a/src/controllers/dashboard/app/app/api/obs/export/route.ts
+++ b/src/controllers/dashboard/app/app/api/obs/export/route.ts
@@ -1,0 +1,75 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth";
+import { resolvePermissions } from "@/lib/permissions";
+import { isWaiterReady } from "@/lib/waiter";
+
+/**
+ * Dev-only OBS config export. Has the connected wmgr client zip up its OBS scene collections +
+ * profiles and base64 it back; the route decodes and serves it as a .zip download.
+ *
+ * SAFETY: credentials never leave the machine — the PowerShell excludes `service.json*` (the Twitch
+ * stream key) and redacts token/key lines in `basic.ini` (OAuth) before zipping.
+ *
+ *   POST { wuid }  →  application/zip  (obs-config-<name>.zip)
+ */
+export const dynamic = "force-dynamic";
+
+// Runs on the client's machine (pwsh). Copies scenes/*.json + profiles/** to a temp dir, excluding
+// service.json* and redacting basic.ini secrets, Compress-Archives it, and emits the zip as base64.
+const EXPORT_CMD =
+  String.raw`$b="$env:APPDATA\obs-studio\basic"; $t=Join-Path $env:TEMP ("obsexp_"+[guid]::NewGuid().ToString('N')); ni -ItemType Directory -Force "$t\scenes","$t\profiles" | Out-Null; Copy-Item "$b\scenes\*.json" "$t\scenes" -Force -EA 0; Get-ChildItem "$b\profiles" -Directory -EA 0 | %{ $pd=Join-Path "$t\profiles" $_.Name; ni -ItemType Directory -Force $pd | Out-Null; Get-ChildItem $_.FullName -File -EA 0 | ?{ $_.Name -notmatch '^service\.json' } | %{ if($_.Name -eq 'basic.ini'){ (Get-Content $_.FullName) -replace '^(Token|RefreshToken|Key|BindIP|UUID)=.*','$1=<redacted>' | Set-Content (Join-Path $pd $_.Name) } else { Copy-Item $_.FullName $pd -Force } } }; $zip="$t.zip"; if(Test-Path $zip){Remove-Item $zip -Force}; Compress-Archive -Path (Join-Path $t '*') -DestinationPath $zip -Force; [Convert]::ToBase64String([IO.File]::ReadAllBytes($zip)); Remove-Item $t -Recurse -Force -EA 0; Remove-Item $zip -Force -EA 0`;
+
+function findClient(wuid: string): any | null {
+  return [...((global as any).manager?.clients ?? [])].find((c: any) => c.waiterUserId === wuid) ?? null;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isWaiterReady()) return NextResponse.json({ error: "Waiter not ready" }, { status: 503 });
+  const session = await getSessionFromRequest();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const perms = await resolvePermissions(session);
+  if (!perms.isDev) return NextResponse.json({ error: "Forbidden – dev only" }, { status: 403 });
+
+  const body = await req.json().catch(() => null);
+  const wuid: string = typeof body?.wuid === "string" ? body.wuid : "";
+  if (!wuid) return NextResponse.json({ error: "wuid required" }, { status: 400 });
+
+  const client = findClient(wuid);
+  if (!client) return NextResponse.json({ error: "Manager client not connected", code: "CLIENT_OFFLINE" }, { status: 404 });
+  if (typeof client.runCommand !== "function") return NextResponse.json({ error: "This client doesn't support remote commands" }, { status: 400 });
+
+  const actor = session?.displayName ?? session?.twitchLogin ?? session?.twitchId ?? "dev";
+  (global as any).logDashboardEvent?.({
+    category: "obs", action: "export", wuid: String(wuid),
+    channelId: (global as any).channelIdForWuid?.(String(wuid)), actor: { name: actor }, summary: "export OBS config",
+  });
+
+  let result: any;
+  try {
+    result = await client.runCommand(EXPORT_CMD, "pwsh");
+  } catch (err: any) {
+    return NextResponse.json({ error: `Export failed: ${err?.message ?? err}` }, { status: 500 });
+  }
+
+  // PowerShell may append CLIXML progress noise; keep only the base64 that precedes it.
+  let out = String(result?.output ?? "");
+  out = out.split("#< CLIXML")[0];
+  const b64 = out.replace(/[^A-Za-z0-9+/=]/g, "");
+  if (!b64) return NextResponse.json({ error: "Empty response from client", raw: String(result?.output ?? "").slice(0, 300) }, { status: 502 });
+
+  const buf = Buffer.from(b64, "base64");
+  // A real zip starts with "PK\x03\x04" — guard against error text sneaking through.
+  if (buf.length < 4 || buf[0] !== 0x50 || buf[1] !== 0x4b) {
+    return NextResponse.json({ error: "Client did not return a zip", raw: out.slice(0, 200) }, { status: 502 });
+  }
+
+  const name = String(client.displayName ?? wuid).replace(/[^\w.-]+/g, "_");
+  return new NextResponse(buf, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="obs-config-${name}.zip"`,
+      "Content-Length": String(buf.length),
+    },
+  });
+}

--- a/src/controllers/dashboard/app/app/api/triggers/clone/route.ts
+++ b/src/controllers/dashboard/app/app/api/triggers/clone/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth";
+import { resolvePermissions, canManageChannel } from "@/lib/permissions";
+import { getStreamerById, isWaiterReady } from "@/lib/waiter";
+import { buildAction, summarizeAction, createRewardFromConfig } from "../actions";
+
+/**
+ * Clone a user-created redemption trigger onto another channel.
+ *
+ *   POST { from, id, to }
+ *     from = source broadcaster twitch id (owner of the trigger)
+ *     id   = record::id of the `redemption_triggers` row
+ *     to   = target broadcaster twitch id
+ *     → { success:true, trigger, actionRebound }
+ *
+ * A brand-new channel-point reward is created on the target from the source's stored
+ * `reward_config`, and a fresh `redemption_triggers` row is written for the target. The source
+ * is never modified.
+ *
+ * ONLY managed rewards (reward_config.mode === "create") can be cloned. A trigger in
+ * mode:"existing" is bound to a reward id that only exists on the source channel — copying that
+ * id to another channel would produce a row pointing at a reward the target doesn't own, which
+ * would silently never fire. That case is rejected with an explanatory error instead.
+ *
+ * Permissions mirror the endpoints this composes: reading the source needs the same access as
+ * `GET /api/triggers` (any channel manager), while creating on the target needs the same access
+ * as `POST /api/triggers` (broadcaster or dev).
+ */
+export async function POST(req: NextRequest) {
+  if (!isWaiterReady()) return NextResponse.json({ error: "Waiter not ready" }, { status: 503 });
+
+  const body = await req.json().catch(() => null);
+  const fromChannel: string = typeof body?.from === "string" ? body.from : "";
+  const toChannel: string = typeof body?.to === "string" ? body.to : "";
+  const id: string = typeof body?.id === "string" ? body.id : "";
+
+  if (!fromChannel || !toChannel || !id) {
+    return NextResponse.json({ error: "from, to and id required" }, { status: 400 });
+  }
+  if (fromChannel === toChannel) {
+    return NextResponse.json({ error: "Source and target channel are the same" }, { status: 400 });
+  }
+
+  const session = await getSessionFromRequest();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const perms = await resolvePermissions(session);
+
+  // Source: read access (GET /api/triggers level).
+  if (!canManageChannel(perms, fromChannel)) {
+    return NextResponse.json({ error: "Forbidden (source channel)" }, { status: 403 });
+  }
+  // Target: create access (POST /api/triggers level).
+  const targetPerms = canManageChannel(perms, toChannel);
+  if (!targetPerms || (!targetPerms.isBroadcaster && !perms.isDev)) {
+    return NextResponse.json({ error: "Forbidden (target channel)" }, { status: 403 });
+  }
+
+  const targetStreamer = getStreamerById(toChannel);
+  if (!targetStreamer) return NextResponse.json({ error: "Target channel not connected" }, { status: 404 });
+
+  const db: any = (global as any).db;
+
+  // Match on the record's id PART, same as /api/triggers/[id] — auto-generated ids don't
+  // round-trip through type::record() reliably.
+  const rows = await db
+    .query(`SELECT * FROM redemption_triggers WHERE record::id(id) = $id AND owner_twitch_id = $owner`, {
+      id,
+      owner: fromChannel,
+    })
+    .catch(() => [[]]);
+  const source = rows?.[0]?.[0] ?? null;
+  if (!source) return NextResponse.json({ error: "Trigger not found" }, { status: 404 });
+
+  const cfg = source.reward_config;
+  if (!cfg || cfg.mode !== "create") {
+    return NextResponse.json(
+      {
+        error:
+          "Only Waiter-managed rewards can be cloned. This trigger is linked to an existing reward that only exists on the source channel.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // Re-resolve the action against the TARGET channel so a target-owned script/preset of the same
+  // name wins. If the target can't resolve it, fall back to the source's compiled snapshot — the
+  // stored action carries its own compiled steps, so the clone still works standalone.
+  let action = source.action;
+  let actionRebound = false;
+  const rebuilt = await buildAction(rebindableAction(source.action), toChannel, session.twitchId);
+  if (rebuilt.action) {
+    action = rebuilt.action;
+    actionRebound = true;
+  }
+
+  const enabled = source.enabled !== false;
+
+  let rewardId = "";
+  try {
+    const created = await createRewardFromConfig(targetStreamer, cfg, enabled);
+    rewardId = created?.id ?? "";
+    if (!rewardId) {
+      return NextResponse.json(
+        { error: "Could not create reward on the target channel (channel points require affiliate/partner)" },
+        { status: 400 },
+      );
+    }
+  } catch (err: any) {
+    return NextResponse.json({ error: `Failed to create reward: ${err?.message ?? err}` }, { status: 502 });
+  }
+
+  const name: string = typeof source.name === "string" ? source.name : "Cloned trigger";
+  const statistical = source.statistical === true;
+
+  await db.query(
+    `UPSERT redemption_triggers
+       SET owner_twitch_id = $owner, name = $name, installed = true, enabled = $enabled,
+           statistical = $statistical, reward_id = $reward_id, manage_reward = true,
+           reward_config = $reward_config, action = $action, created_at = time::now()
+       WHERE owner_twitch_id = $owner AND reward_id = $reward_id`,
+    {
+      owner: toChannel,
+      name,
+      enabled,
+      statistical,
+      reward_id: rewardId,
+      reward_config: cfg,
+      action,
+    },
+  );
+
+  // Interception-connected redemptions are only redeemable while interception is on AND the
+  // stream is live; apply that immediately so the clone starts in the right state.
+  (global as any).syncInterceptionUserTriggers?.((targetStreamer as any).waiterUserId);
+
+  return NextResponse.json({
+    success: true,
+    actionRebound,
+    trigger: {
+      name,
+      installed: true,
+      enabled,
+      statistical,
+      reward_id: rewardId,
+      manage_reward: true,
+      action: summarizeAction(action),
+    },
+  });
+}
+
+/**
+ * Project a stored action back into the API payload shape `buildAction` accepts (it takes the
+ * request-level `{ type, script_name }` / `{ type, preset_name }` form, not the compiled row).
+ * Returns null for unknown types so the caller keeps the original snapshot.
+ */
+function rebindableAction(action: any): any {
+  if (!action || typeof action !== "object") return null;
+  if (action.type === "interception_script") {
+    return { type: "interception_script", script_name: action.script_name };
+  }
+  if (action.type === "interception_preset") {
+    return { type: "interception_preset", preset_name: action.preset_name };
+  }
+  return null;
+}

--- a/src/controllers/discord/commands/link.cmd.ts
+++ b/src/controllers/discord/commands/link.cmd.ts
@@ -1,0 +1,191 @@
+import {
+  type ChatInputCommandInteraction,
+  Colors,
+  EmbedBuilder,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import { RecordId } from "surrealdb";
+import { WaiterCommand } from "../lib/base/WaiterCommand";
+import { upsertDiscordUser } from "../lib/misc";
+import { isOwner } from "../lib/permissions";
+import { ensureTwitchUser, invalidateCache } from "@/lib/misc";
+import { mergeFromTo } from "@sdb/utils";
+import type TwitchClient from "@twitch/client";
+
+/**
+ * `/link` — developer tool that ties a Twitch account to a Discord account on the same Waiter user.
+ *
+ * Normally a Waiter user only gains its `twitch` link by going through the Twitch OAuth flow, and
+ * nothing currently writes `users.discord` at all — so a Discord member has no way to be recognised
+ * as a streamer. This command fills that gap by hand:
+ *
+ *  1. `twitch_users:<id>` is upserted from live Helix data (accepts either a Twitch id or login).
+ *  2. `discord_users:<id>` is upserted for the chosen member (created if it didn't exist).
+ *  3. Both are attached to a single `users` record, creating one if neither side had one.
+ *
+ * When the two sides already belong to *different* Waiter users, the Discord-side user is merged
+ * into the Twitch-side one via `mergeFromTo` — the Twitch side is kept because it owns the
+ * `streamer_tokens` row. `users.twitch` / `users.discord` are both UNIQUE, so linking without that
+ * merge would fail on the index anyway.
+ *
+ * Owner-only (`config.discord.owners`) and hidden from non-admins in the command picker. The gate is
+ * a runtime check rather than the `devOnly` module flag so the command still exists in production
+ * builds, which is where accounts actually need linking.
+ */
+export default class Link extends WaiterCommand {
+  protected _slashCommand = new SlashCommandBuilder()
+    .setName("link")
+    .setDescription("[Developer] Link a Twitch account to a Discord account.")
+    //? Hidden from everyone without Administrator; the real gate is the isOwner() check below.
+    .setDefaultMemberPermissions(0)
+    .addStringOption((opt) =>
+      opt
+        .setName("twitch")
+        .setDescription("The Twitch account — either a numeric user ID or a username/login.")
+        .setRequired(true),
+    )
+    .addUserOption((opt) =>
+      opt.setName("user").setDescription("The Discord member to link that Twitch account to.").setRequired(true),
+    );
+
+  public async runCommand(interaction: ChatInputCommandInteraction) {
+    if (!isOwner(interaction.user.id)) {
+      return void (await interaction.reply({
+        content: "This is a developer-only command.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    const twitch = anyTwitchClient();
+    if (!twitch) {
+      return void (await interaction.reply({
+        content: "The Twitch controller isn't available right now, so accounts can't be resolved.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    const query = interaction.options.getString("twitch", true).trim().replace(/^@/, "");
+    const discordUser = interaction.options.getUser("user", true);
+
+    if (discordUser.bot) {
+      return void (await interaction.editReply("Bots can't be linked to a Twitch account."));
+    }
+
+    // ─── Resolve the Twitch account ──────────────────────────────────────────
+    //? fetchUser() picks id-vs-login itself based on whether the input is all digits.
+    const twitchUser = await twitch.fetchUser(query).catch(() => null);
+    if (!twitchUser?.id) {
+      return void (await interaction.editReply(
+        `No Twitch account found for \`${query}\`. Pass a numeric user ID or an exact username.`,
+      ));
+    }
+
+    const twitchRecord = new RecordId("twitch_users", twitchUser.id);
+    const discordRecord = new RecordId("discord_users", discordUser.id);
+
+    try {
+      // ─── Make sure both sides exist ────────────────────────────────────────
+      await ensureTwitchUser({
+        id: twitchUser.id,
+        login: twitchUser.login,
+        display_name: twitchUser.display_name,
+      });
+
+      await upsertDiscordUser({
+        id: discordUser.id,
+        username: discordUser.username,
+        displayName: discordUser.displayName,
+      });
+
+      // ─── Find whichever Waiter users already hold each side ────────────────
+      const [byTwitch, byDiscord] = await Promise.all([
+        selectUserId("SELECT id FROM users WHERE twitch = $link", twitchRecord),
+        selectUserId("SELECT id FROM users WHERE discord = $link", discordRecord),
+      ]);
+
+      let waiterUserId: RecordId;
+      let action: string;
+
+      if (byTwitch && byDiscord) {
+        if (byTwitch.toString() === byDiscord.toString()) {
+          waiterUserId = byTwitch;
+          action = "Already linked — nothing to change.";
+        } else {
+          //? Two separate Waiter users hold the two halves. Keep the Twitch-side one (it owns the
+          //? streamer_tokens row) and fold the Discord-side one into it; mergeFromTo deletes the
+          //? source and records its id in the survivor's past_ids.
+          waiterUserId = await mergeFromTo(byDiscord, byTwitch);
+          action = `Merged Waiter user \`${byDiscord.toString()}\` into \`${byTwitch.toString()}\`.`;
+        }
+      } else if (byTwitch) {
+        await global.db.query("UPDATE $user SET discord = $link", { user: byTwitch, link: discordRecord });
+        waiterUserId = byTwitch;
+        action = "Attached the Discord account to the existing Twitch-side Waiter user.";
+      } else if (byDiscord) {
+        await global.db.query("UPDATE $user SET twitch = $link", { user: byDiscord, link: twitchRecord });
+        waiterUserId = byDiscord;
+        action = "Attached the Twitch account to the existing Discord-side Waiter user.";
+      } else {
+        const created = await global.db.query("CREATE users SET twitch = $twitch, discord = $discord", {
+          twitch: twitchRecord,
+          discord: discordRecord,
+        });
+
+        //? CREATE comes back as [[record]] here but has been seen flattened to [record] elsewhere in
+        //? this codebase, so accept either rather than silently reading `undefined.id`.
+        const first: any = (created as any)?.[0];
+        const id: RecordId | undefined = (Array.isArray(first) ? first[0] : first)?.id;
+        if (!id) throw new Error("The Waiter user was not returned after creation.");
+        waiterUserId = id;
+        action = "Created a new Waiter user for the pair.";
+      }
+
+      //? getUser() memoises aggressively and is keyed by any of the three ids — a stale entry would
+      //? keep reporting the member as unlinked (e.g. /schedule's Partake button).
+      await Promise.all([
+        invalidateCache(waiterUserId),
+        invalidateCache(twitchUser.id),
+        invalidateCache(discordUser.id),
+      ]);
+
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setColor(Colors.Green)
+            .setTitle("Accounts linked")
+            .setDescription(action)
+            .addFields(
+              {
+                name: "Twitch",
+                value: `[${twitchUser.display_name}](https://twitch.tv/${twitchUser.login})\n\`${twitchUser.id}\``,
+                inline: true,
+              },
+              { name: "Discord", value: `${discordUser}\n\`${discordUser.id}\``, inline: true },
+              { name: "Waiter user", value: `\`${waiterUserId.toString()}\`` },
+            ),
+        ],
+      });
+    } catch (err: any) {
+      global.discord.controller.logger.error("Failed to link a Twitch account to a Discord account.", err);
+      await interaction.editReply(
+        `Linking failed: ${err?.message ?? err}\n-# \`users.twitch\` and \`users.discord\` are both UNIQUE — check whether either side is already claimed by another Waiter user.`,
+      );
+    }
+  }
+}
+
+/** Any connected Twitch client — only used here to resolve a user through Helix. */
+function anyTwitchClient(): TwitchClient | null {
+  return global.twitch?.bot ?? global.twitch?.streamers?.values().next().value ?? null;
+}
+
+/** Run a `SELECT id FROM users WHERE <field> = $link` and return the single id, if any. */
+async function selectUserId(query: string, link: RecordId): Promise<RecordId | null> {
+  const rows = await global.db
+    .query(query, { link })
+    .then((res) => (res?.[0] ?? []) as { id: RecordId }[]);
+  return rows[0]?.id ?? null;
+}

--- a/src/controllers/discord/commands/schedule.cmd.ts
+++ b/src/controllers/discord/commands/schedule.cmd.ts
@@ -1,0 +1,687 @@
+import {
+  ActionRowBuilder,
+  AttachmentBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type Attachment,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type ChatInputCommandInteraction,
+  type Client,
+  Colors,
+  EmbedBuilder,
+  Events,
+  type GuildMember,
+  type Interaction,
+  type Message,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import moment from "moment-timezone";
+import { WaiterCommand } from "../lib/base/WaiterCommand";
+import { getDiscordUser, resolveRole } from "../lib/misc";
+import { isOwner } from "../lib/permissions";
+import { getUser } from "@/lib/misc";
+import type TwitchClient from "@twitch/client";
+import { SEGMENT_MAX_DURATION, SEGMENT_MIN_DURATION } from "@twitch/funcs/schedule";
+
+/**
+ * `/schedule` — announce a co-stream and let other streamers put it on their own Twitch schedule.
+ *
+ * A member of the Streamers role picks a Twitch category (autocompleted live against Helix's
+ * `/search/categories`), a title, a start time and optionally an end time, a poster image and a
+ * description. Waiter posts an embed to the channel carrying all of it, plus **Partake** /
+ * **Withdraw** buttons.
+ *
+ * Pressing **Partake** creates a segment on that streamer's *own* Twitch schedule
+ * (`POST /schedule/segment`, requires the `channel:manage:schedule` scope which Waiter already asks
+ * for) and adds them to the embed's "Partaking" list. **Withdraw** deletes exactly the segment that
+ * was created for them and drops them from the list again. The person who ran the command is
+ * partaken automatically — they're the one proposing the stream.
+ *
+ * State lives in `discord_scheduled_streams` (see `schedule.tables.ts`), keyed by the announcement
+ * message id, so the buttons keep working across restarts.
+ *
+ * The controller's central InteractionCreate dispatcher only routes chat-input commands, so the
+ * button listener is registered in `setup()` — same convention as the LIVE-warning consent buttons
+ * (see events/onJoinLIVEWarning.evt.ts).
+ */
+
+const PARTAKE_ID = "schedule:partake";
+const WITHDRAW_ID = "schedule:withdraw";
+
+/** Fallback used to find the Streamers role when `config.discord.roles.streamer` isn't set. */
+const STREAMER_ROLE_FALLBACK = /^streamers?$/i;
+
+/** Discord's default per-file upload ceiling is 10 MiB; stay under it with room to spare. */
+const MAX_POSTER_BYTES = 8 * 1024 * 1024;
+
+type Partaker = {
+  discord_id: string;
+  twitch_id: string;
+  display_name: string;
+  segment_id: string;
+};
+
+type ScheduledStreamRow = {
+  message_id: string;
+  channel_id: string;
+  guild_id: string;
+  created_by: string;
+  title: string;
+  description?: string | null;
+  game_id: string;
+  game_name: string;
+  poster_url?: string | null;
+  start_time: string | Date;
+  end_time?: string | Date | null;
+  duration: number;
+  timezone: string;
+  partakers: Partaker[];
+};
+
+export default class Schedule extends WaiterCommand {
+  protected _slashCommand = new SlashCommandBuilder()
+    .setName("schedule")
+    .setDescription("Announce a stream and let other streamers add it to their Twitch schedule.")
+    .addStringOption((opt) =>
+      opt
+        .setName("game")
+        .setDescription("The Twitch category/game being streamed.")
+        .setRequired(true)
+        .setAutocomplete(true),
+    )
+    .addStringOption((opt) =>
+      opt
+        .setName("title")
+        .setDescription("The stream title (max 140 characters, Twitch's limit).")
+        .setRequired(true)
+        .setMaxLength(140),
+    )
+    .addStringOption((opt) =>
+      opt
+        .setName("start")
+        .setDescription("When it starts, e.g. \"2026-08-14 20:00\" or a unix timestamp. Uses your timezone.")
+        .setRequired(true),
+    )
+    .addStringOption((opt) =>
+      opt
+        .setName("end")
+        .setDescription("When it ends — a full date, a time like \"23:30\", or a duration like \"3h30m\".")
+        .setRequired(false),
+    )
+    .addStringOption((opt) =>
+      opt.setName("description").setDescription("Extra details shown on the announcement.").setRequired(false),
+    )
+    .addAttachmentOption((opt) =>
+      opt
+        .setName("poster")
+        .setDescription("Poster image for the announcement. Defaults to the game's box art.")
+        .setRequired(false),
+    );
+
+  /** Serializes button presses per announcement so two simultaneous partakes can't clobber each other. */
+  private locks = new Map<string, Promise<void>>();
+  private interactionListener: ((interaction: Interaction) => void) | null = null;
+
+  public override async setup(client: Client, reason: "reload" | "startup" | "duringRun" | null) {
+    this.interactionListener = (interaction: Interaction) => {
+      void this.handleButton(interaction);
+    };
+    client.on(Events.InteractionCreate, this.interactionListener);
+    return super.setup(client, reason);
+  }
+
+  public override async unload(client: Client, reason: "reload" | "shuttingDown" | null) {
+    if (this.interactionListener) {
+      client.off(Events.InteractionCreate, this.interactionListener);
+      this.interactionListener = null;
+    }
+    return super.unload(client, reason);
+  }
+
+  // ─── Autocomplete ──────────────────────────────────────────────────────────
+
+  public override async autocomplete(interaction: AutocompleteInteraction) {
+    const query = interaction.options.getFocused()?.trim();
+    const client = anyTwitchClient();
+    if (!query || !client) return void (await interaction.respond([]));
+
+    const categories = await client.searchCategories(query, 25).catch(() => []);
+    await interaction.respond(
+      categories.slice(0, 25).map((category) => ({
+        //? Choice names are capped at 100 characters by Discord; the value is the Twitch game id.
+        name: category.name.slice(0, 100),
+        value: category.id,
+      })),
+    );
+  }
+
+  // ─── /schedule ─────────────────────────────────────────────────────────────
+
+  public async runCommand(interaction: ChatInputCommandInteraction) {
+    if (!interaction.inCachedGuild()) {
+      return void (await interaction.reply({
+        content: "This command can only be used in the server.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    if (!(await this.isStreamer(interaction.member))) {
+      return void (await interaction.reply({
+        content: "Only members of the Streamers role can schedule streams.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    const channel = interaction.channel;
+    if (!channel?.isSendable()) {
+      return void (await interaction.reply({
+        content: "I can't post the announcement in this channel.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    const twitch = anyTwitchClient();
+    if (!twitch) {
+      return void (await interaction.reply({
+        content: "The Twitch controller isn't available right now, so streams can't be scheduled.",
+        flags: MessageFlags.Ephemeral,
+      }));
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    // ─── Times ───────────────────────────────────────────────────────────────
+    const timezone = (await getDiscordUser(interaction.user.id).catch(() => null))?.timezone || "UTC";
+
+    const start = parseWhen(interaction.options.getString("start", true), timezone);
+    if (!start) {
+      return void (await interaction.editReply(
+        "I couldn't understand that start time. Try `2026-08-14 20:00`, `2026-08-14 8:00 PM` or a unix timestamp.",
+      ));
+    }
+    if (start.valueOf() <= Date.now()) {
+      return void (await interaction.editReply(
+        `That start time is in the past (read as <t:${Math.floor(start.valueOf() / 1000)}:F> in \`${timezone}\`). Set your timezone with \`/settimezone\` if that looks wrong.`,
+      ));
+    }
+
+    const rawEnd = interaction.options.getString("end");
+    let end: Date | null = null;
+    let duration = 240; //? Twitch's own default segment length.
+    if (rawEnd) {
+      end = parseEnd(rawEnd, start, timezone);
+      if (!end) {
+        return void (await interaction.editReply(
+          "I couldn't understand that end time. Try a full date, a time like `23:30`, or a duration like `3h30m`.",
+        ));
+      }
+      duration = Math.round((end.valueOf() - start.valueOf()) / 60000);
+      if (duration < SEGMENT_MIN_DURATION || duration > SEGMENT_MAX_DURATION) {
+        return void (await interaction.editReply(
+          `Twitch only accepts stream lengths between ${SEGMENT_MIN_DURATION} minutes and ${SEGMENT_MAX_DURATION} minutes (23 hours). That end time works out to ${duration} minutes.`,
+        ));
+      }
+    }
+
+    // ─── Game ────────────────────────────────────────────────────────────────
+    const game = await resolveGame(twitch, interaction.options.getString("game", true));
+    if (!game) {
+      return void (await interaction.editReply(
+        "I couldn't find that game on Twitch. Pick one of the autocomplete suggestions.",
+      ));
+    }
+
+    const title = interaction.options.getString("title", true).trim().slice(0, 140);
+    const description = interaction.options.getString("description")?.trim() || null;
+
+    // ─── Poster ──────────────────────────────────────────────────────────────
+    const posterOption = interaction.options.getAttachment("poster");
+    let posterFile: AttachmentBuilder | null = null;
+    if (posterOption) {
+      const problem = validatePoster(posterOption);
+      if (problem) return void (await interaction.editReply(problem));
+      //? Re-upload the poster onto the announcement itself. Attachment URLs handed to us by the
+      //? interaction are signed and expire, so linking them straight into the embed would leave a
+      //? broken image within a day; owning the attachment means the embed can always be rebuilt
+      //? from the message's own (freshly signed) attachment URL.
+      posterFile = await downloadPoster(posterOption).catch(() => null);
+      if (!posterFile) {
+        return void (await interaction.editReply("I couldn't download that poster image. Try uploading it again."));
+      }
+    }
+    const boxArt = boxArtUrl(game.box_art_url, game.id);
+
+    // ─── Auto-partake the author ─────────────────────────────────────────────
+    const partakers: Partaker[] = [];
+    let authorNote = "";
+    const authorClient = await resolveStreamerClient(interaction.user.id);
+    if (!authorClient) {
+      authorNote =
+        "\n-# Your own Twitch account isn't linked/connected, so the stream wasn't added to your schedule.";
+    } else {
+      try {
+        const segment = await authorClient.createScheduleSegment({
+          startTime: start,
+          timezone,
+          durationMinutes: duration,
+          categoryId: game.id,
+          title,
+        });
+        partakers.push({
+          discord_id: interaction.user.id,
+          twitch_id: authorClient.IAM.id,
+          display_name: authorClient.IAM.display_name ?? authorClient.IAM.login,
+          segment_id: segment.id,
+        });
+      } catch (err: any) {
+        authorNote = `\n-# The stream couldn't be added to your own Twitch schedule: ${err?.message ?? err}`;
+      }
+    }
+
+    // ─── Post ────────────────────────────────────────────────────────────────
+    const row: ScheduledStreamRow = {
+      message_id: "",
+      channel_id: channel.id,
+      guild_id: interaction.guildId,
+      created_by: interaction.user.id,
+      title,
+      description,
+      game_id: game.id,
+      game_name: game.name,
+      poster_url: boxArt,
+      start_time: start,
+      end_time: end,
+      duration,
+      timezone,
+      partakers,
+    };
+
+    const message = await channel.send({
+      embeds: [buildEmbed(row, posterFile ? `attachment://${posterFile.name}` : boxArt)],
+      components: [buildButtons()],
+      ...(posterFile ? { files: [posterFile] } : {}),
+    });
+
+    row.message_id = message.id;
+
+    try {
+      //? `description`/`end_time` are `string|none` / `datetime|none` in the schema — a literal null
+      //? is rejected, so those keys are omitted entirely when unset rather than sent as null.
+      const content: Record<string, any> = {
+        ...row,
+        start_time: start, //? SurrealDB wants a real Date here, never an ISO string.
+      };
+      if (!description) delete content.description;
+      if (end) content.end_time = end;
+      else delete content.end_time;
+
+      await global.db.query("INSERT INTO discord_scheduled_streams $content", { content });
+    } catch (err) {
+      //? Without a row the buttons have nothing to act on — don't leave a dead announcement up,
+      //? and roll back the segment we already put on the author's Twitch schedule.
+      log().error("Failed to store the scheduled stream, removing the announcement.", err);
+      await message.delete().catch(() => {});
+      const authorSegment = partakers[0]?.segment_id;
+      if (authorClient && authorSegment) await authorClient.deleteScheduleSegment(authorSegment).catch(() => {});
+      return void (await interaction.editReply(
+        "The announcement couldn't be saved, so it was removed. Please try again.",
+      ));
+    }
+
+    await interaction.editReply(`Announcement posted: ${message.url}${authorNote}`);
+  }
+
+  // ─── Buttons ───────────────────────────────────────────────────────────────
+
+  private async handleButton(interaction: Interaction) {
+    if (!interaction.isButton()) return;
+    if (interaction.customId !== PARTAKE_ID && interaction.customId !== WITHDRAW_ID) return;
+
+    //? Acknowledge BEFORE queueing: Discord invalidates an interaction that goes unanswered for 3
+    //? seconds, and a press that has to wait behind other presses on the same announcement could
+    //? easily exceed that. Every reply below is therefore an editReply on this deferred response.
+    const acknowledged = await interaction
+      .deferReply({ flags: MessageFlags.Ephemeral })
+      .then(() => true)
+      .catch(() => false);
+    if (!acknowledged) return;
+
+    //? One announcement is edited at a time, so simultaneous presses queue instead of racing on a
+    //? read-modify-write of the partakers array.
+    const key = interaction.message.id;
+    const previous = this.locks.get(key) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {})
+      .then(() => this.runButton(interaction))
+      .catch((err) => {
+        log().error("Error while handling a /schedule button.", err);
+      })
+      .finally(() => {
+        if (this.locks.get(key) === next) this.locks.delete(key);
+      });
+    this.locks.set(key, next);
+    await next;
+  }
+
+  private async runButton(interaction: ButtonInteraction) {
+    if (!interaction.inCachedGuild()) return;
+
+    const row = await getRow(interaction.message.id);
+    if (!row) {
+      return void (await interaction.editReply(
+        "I've lost track of this announcement, so its buttons no longer work.",
+      ));
+    }
+
+    if (!(await this.isStreamer(interaction.member))) {
+      return void (await interaction.editReply("Only members of the Streamers role can partake in a stream."));
+    }
+
+    const withdrawing = interaction.customId === WITHDRAW_ID;
+    const existing = row.partakers.find((p) => p.discord_id === interaction.user.id) ?? null;
+
+    if (withdrawing && !existing) {
+      return void (await interaction.editReply("You aren't partaking in this stream."));
+    }
+    if (!withdrawing && existing) {
+      return void (await interaction.editReply(
+        "You're already partaking in this stream. Press **Withdraw** to back out.",
+      ));
+    }
+
+    const client = await resolveStreamerClient(interaction.user.id);
+    if (!client) {
+      return void (await interaction.editReply(
+        "Your Twitch account isn't linked to Waiter (or its client isn't connected right now), so I can't touch your schedule.",
+      ));
+    }
+
+    const start = new Date(row.start_time);
+    if (!withdrawing && start.valueOf() <= Date.now()) {
+      return void (await interaction.editReply(
+        "This stream's start time has already passed, so it can't be added to a schedule anymore.",
+      ));
+    }
+
+    let partakers: Partaker[];
+    let notice: string;
+
+    if (withdrawing) {
+      const removed = await client.deleteScheduleSegment(existing!.segment_id);
+      partakers = row.partakers.filter((p) => p.discord_id !== interaction.user.id);
+      notice = removed
+        ? "You've withdrawn, and the stream was removed from your Twitch schedule."
+        : "You've withdrawn, but the segment couldn't be removed from your Twitch schedule — remove it manually.";
+    } else {
+      let segmentId: string;
+      try {
+        const segment = await client.createScheduleSegment({
+          startTime: start,
+          timezone: row.timezone || "UTC",
+          durationMinutes: row.duration,
+          categoryId: row.game_id,
+          title: row.title,
+        });
+        segmentId = segment.id;
+      } catch (err: any) {
+        return void (await interaction.editReply(
+          `Twitch wouldn't add the stream to your schedule: ${err?.message ?? err}`,
+        ));
+      }
+      partakers = [
+        ...row.partakers,
+        {
+          discord_id: interaction.user.id,
+          twitch_id: client.IAM.id,
+          display_name: client.IAM.display_name ?? client.IAM.login,
+          segment_id: segmentId,
+        },
+      ];
+      notice = "You're partaking — the stream has been added to your Twitch schedule.";
+    }
+
+    await global.db.query(
+      "UPDATE discord_scheduled_streams SET partakers = $partakers WHERE message_id = $messageId",
+      { partakers, messageId: interaction.message.id },
+    );
+
+    await this.refreshEmbed(interaction.message, { ...row, partakers });
+
+    await interaction.editReply(notice);
+  }
+
+  /** Rebuild the announcement embed in place, keeping whatever poster the message already carries. */
+  private async refreshEmbed(message: Message, row: ScheduledStreamRow) {
+    //? The message's own attachment URL is re-signed every time the message is fetched, so reading
+    //? it here (rather than storing it) keeps the poster from expiring.
+    const poster = message.attachments.first()?.url ?? row.poster_url ?? null;
+    await message.edit({ embeds: [buildEmbed(row, poster)], components: [buildButtons()] });
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+
+  /** Whether the member holds the configured Streamers role (owners always pass). */
+  private async isStreamer(member: GuildMember): Promise<boolean> {
+    if (isOwner(member.id)) return true;
+    const role = await resolveRole(
+      member.guild,
+      global.config.discord.roles?.streamer ?? null,
+      STREAMER_ROLE_FALLBACK,
+    );
+    if (!role) return false;
+    return member.roles.cache.has(role.id);
+  }
+}
+
+// ─── Module-level helpers ────────────────────────────────────────────────────
+
+/** The Discord controller's logger (the base class keeps its own `logger` private). */
+function log() {
+  return global.discord.controller.logger;
+}
+
+/** Any connected Twitch client — used for read-only lookups (category search, game info). */
+function anyTwitchClient(): TwitchClient | null {
+  return global.twitch?.bot ?? global.twitch?.streamers?.values().next().value ?? null;
+}
+
+/** A Discord member's own streamer client, via their linked Twitch account. */
+async function resolveStreamerClient(discordId: string): Promise<TwitchClient | null> {
+  const linked = await getUser(discordId).catch(() => null);
+  const twitchId = linked?.twitch?.id?.id?.toString();
+  if (!twitchId) return null;
+  return global.twitch?.streamers?.get(twitchId) ?? null;
+}
+
+/**
+ * Turn the `game` option into a real Twitch category. Autocomplete hands back an id, but a member
+ * can also submit free text without picking a suggestion — fall back to searching for it.
+ */
+async function resolveGame(
+  client: TwitchClient,
+  value: string,
+): Promise<{ id: string; name: string; box_art_url?: string } | null> {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  //? getGame() already picks the id-vs-name lookup itself based on whether the input is numeric,
+  //? so one call covers both "came from autocomplete" and "typed the exact game name".
+  const exact = await client.getGame(trimmed).catch(() => null);
+  if (exact?.id) return exact;
+
+  const [firstMatch] = await client.searchCategories(trimmed, 1).catch(() => []);
+  return firstMatch ?? null;
+}
+
+/** Box art at a usable size, falling back to Twitch's predictable CDN path. */
+function boxArtUrl(template: string | undefined, gameId: string): string {
+  if (template) return template.replace("{width}", "285").replace("{height}", "380");
+  return `https://static-cdn.jtvnw.net/ttv-boxart/${gameId}-285x380.jpg`;
+}
+
+/** Reject non-images / oversized uploads before we try to mirror them onto the announcement. */
+function validatePoster(attachment: Attachment): string | null {
+  if (attachment.contentType && !attachment.contentType.startsWith("image/")) {
+    return "The poster has to be an image.";
+  }
+  if (attachment.size > MAX_POSTER_BYTES) {
+    return `That poster is too large (${Math.round(attachment.size / 1024 / 1024)} MB). Keep it under 8 MB.`;
+  }
+  return null;
+}
+
+/** Mirror the uploaded poster into a file we can attach to the announcement message ourselves. */
+async function downloadPoster(attachment: Attachment): Promise<AttachmentBuilder> {
+  const res = await fetch(attachment.url);
+  if (!res.ok) throw new Error(`Poster download failed with ${res.status}`);
+  const buffer = Buffer.from(await res.arrayBuffer());
+
+  //? `attachment://` references can't contain spaces or exotic characters.
+  const safeName = (attachment.name || "poster.png").replace(/[^a-zA-Z0-9._-]/g, "_");
+  return new AttachmentBuilder(buffer, { name: safeName });
+}
+
+function buildButtons(): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId(PARTAKE_ID).setLabel("Partake").setEmoji("🎬").setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId(WITHDRAW_ID).setLabel("Withdraw").setStyle(ButtonStyle.Secondary),
+  );
+}
+
+function buildEmbed(row: ScheduledStreamRow, poster: string | null): EmbedBuilder {
+  const start = new Date(row.start_time);
+  const startUnix = Math.floor(start.valueOf() / 1000);
+
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Purple)
+    .setTitle(row.title)
+    .addFields(
+      { name: "Game", value: row.game_name, inline: true },
+      { name: "Starts", value: `<t:${startUnix}:F>\n(<t:${startUnix}:R>)`, inline: true },
+    )
+    .setFooter({
+      text: "Press Partake to add this stream to your own Twitch schedule • Times are shown in your own timezone",
+    });
+
+  //? Mentions render inside an embed description (they don't in a footer), so the proposer goes here.
+  const blurb = [row.description?.trim(), `-# Proposed by <@${row.created_by}>`].filter(Boolean).join("\n\n");
+  embed.setDescription(blurb.slice(0, 4096));
+
+  if (row.end_time) {
+    const endUnix = Math.floor(new Date(row.end_time).valueOf() / 1000);
+    embed.addFields({ name: "Ends", value: `<t:${endUnix}:F>`, inline: true });
+  }
+
+  embed.addFields({
+    name: `Partaking (${row.partakers.length})`,
+    value: row.partakers.length
+      ? row.partakers
+          .map((p) => `<@${p.discord_id}> — [${p.display_name}](https://twitch.tv/${p.display_name})`)
+          .join("\n")
+          .slice(0, 1024)
+      : "*Nobody yet — press **Partake** to add this to your Twitch schedule.*",
+  });
+
+  if (poster) embed.setImage(poster);
+  return embed;
+}
+
+async function getRow(messageId: string): Promise<ScheduledStreamRow | null> {
+  const rows = await global.db
+    .query("SELECT * FROM discord_scheduled_streams WHERE message_id = $messageId", { messageId })
+    .then((res) => (res?.[0] ?? []) as ScheduledStreamRow[])
+    .catch(() => [] as ScheduledStreamRow[]);
+
+  const row = rows[0];
+  if (!row) return null;
+  return { ...row, partakers: Array.isArray(row.partakers) ? row.partakers : [] };
+}
+
+// ─── Time parsing ────────────────────────────────────────────────────────────
+
+const DATE_FORMATS = [
+  "YYYY-MM-DD HH:mm",
+  "YYYY-MM-DD HH:mm:ss",
+  "YYYY-MM-DDTHH:mm",
+  "YYYY-MM-DDTHH:mm:ss",
+  "YYYY-MM-DD h:mm A",
+  "YYYY-MM-DD h A",
+  "YYYY/MM/DD HH:mm",
+  "DD-MM-YYYY HH:mm",
+  "DD/MM/YYYY HH:mm",
+  "MMM D YYYY HH:mm",
+  "MMM D, YYYY HH:mm",
+  "D MMM YYYY HH:mm",
+];
+
+const TIME_ONLY_FORMATS = ["HH:mm", "HH:mm:ss", "h:mm A", "h A"];
+
+/**
+ * Parse a user-supplied absolute time in `timezone`. Accepts the formats above, a bare unix
+ * timestamp, an ISO-8601 string with its own offset, and Discord's own `<t:...>` markup (handy for
+ * copy-pasting a time out of another message).
+ */
+function parseWhen(input: string, timezone: string): Date | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  const discordStamp = raw.match(/^<t:(-?\d+)(?::[a-zA-Z])?>$/);
+  if (discordStamp) return new Date(Number(discordStamp[1]) * 1000);
+
+  if (/^\d{9,11}$/.test(raw)) return new Date(Number(raw) * 1000);
+
+  //? An explicit offset/Z means the user already pinned the instant — don't reinterpret it.
+  if (/(?:Z|[+-]\d{2}:?\d{2})$/.test(raw)) {
+    const iso = moment.parseZone(raw);
+    if (iso.isValid()) return iso.toDate();
+  }
+
+  const strict = moment.tz(raw, DATE_FORMATS, true, timezone);
+  if (strict.isValid()) return strict.toDate();
+
+  return null;
+}
+
+/**
+ * Parse the `end` option, which may be an absolute time, a bare time-of-day (taken as the first
+ * such time at or after the start), or a duration relative to the start (`3h`, `90m`, `1h30m`, `90`).
+ */
+function parseEnd(input: string, start: Date, timezone: string): Date | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  const absolute = parseWhen(raw, timezone);
+  if (absolute) return absolute;
+
+  const duration = parseDuration(raw);
+  if (duration !== null) return new Date(start.valueOf() + duration * 60000);
+
+  const timeOnly = moment.tz(raw, TIME_ONLY_FORMATS, true, timezone);
+  if (timeOnly.isValid()) {
+    const startMoment = moment(start).tz(timezone);
+    const candidate = startMoment
+      .clone()
+      .hour(timeOnly.hour())
+      .minute(timeOnly.minute())
+      .second(0)
+      .millisecond(0);
+    //? "20:00 → 02:00" obviously means the small hours of the next day.
+    if (candidate.valueOf() <= start.valueOf()) candidate.add(1, "day");
+    return candidate.toDate();
+  }
+
+  return null;
+}
+
+/** `3h`, `90m`, `1h30m`, `2h 15m` or a bare number of minutes → minutes. */
+function parseDuration(input: string): number | null {
+  const raw = input.trim().toLowerCase();
+
+  if (/^\d+$/.test(raw)) return Number(raw);
+
+  const match = raw.match(/^(?:(\d+)\s*h(?:ours?|rs?)?)?\s*(?:(\d+)\s*m(?:in(?:ute)?s?)?)?$/);
+  if (!match || (!match[1] && !match[2])) return null;
+  return Number(match[1] ?? 0) * 60 + Number(match[2] ?? 0);
+}

--- a/src/controllers/discord/index.ts
+++ b/src/controllers/discord/index.ts
@@ -95,7 +95,7 @@ export default class DiscordController extends Controller {
             .describe("Whether the starboard is enabled.")
             .default(false),
           channel: z.string()
-            .describe("The starboard channel. Either a channel name prefixed with '#' (e.g. \"#starboard\") or a channel ID prefixed with '@' (e.g. \"@123456789\"). If null, a channel with 'starboard' in its name is used.")
+            .describe("The starboard channel. Either a channel ID prefixed with '#' (e.g. \"#123456789\") or a channel name prefixed with '@' (e.g. \"@starboard\"). If null, a channel with 'starboard' in its name is used.")
             .nullable()
             .default(null),
           emoji: z.string()
@@ -112,11 +112,11 @@ export default class DiscordController extends Controller {
             .describe("Whether birthday announcements are enabled.")
             .default(true),
           channel: z.string()
-            .describe("The channel to send birthday messages in. Either a channel name prefixed with '#' or a channel ID prefixed with '@'. If null, a channel with 'birthdays' in its name is used.")
+            .describe("The channel to send birthday messages in. Either a channel ID prefixed with '#' or a channel name prefixed with '@'. If null, a channel with 'birthdays' in its name is used.")
             .nullable()
             .default(null),
           role: z.string()
-            .describe("The role to give users on their birthday. Either a role name prefixed with '#' or a role ID prefixed with '@'. If null, a role with 'birthday' in its name is used.")
+            .describe("The role to give users on their birthday. Either a role ID prefixed with '#' or a role name prefixed with '@'. If null, a role with 'birthday' in its name is used.")
             .nullable()
             .default(null),
         })
@@ -131,16 +131,17 @@ export default class DiscordController extends Controller {
         roles: z.object({
           mod: z.string().nullable().default(null).describe("Moderator role ID (punish/offense/ticket/stage tools)."),
           admin: z.string().nullable().default(null).describe("Admin role ID (edit/entry/rules/set/drbot tools)."),
+          streamer: z.string().nullable().default(null).describe("Streamer role — can use /schedule and press its Partake button. Either a role ID prefixed with '#' or a role name prefixed with '@'. If null, a role named 'streamer(s)' is used."),
         })
           .describe("Role IDs for permission tiers.")
-          .default({ mod: null, admin: null }),
+          .default({ mod: null, admin: null, streamer: null }),
         channels: z.object({
           modLog: z.string().nullable().default(null).describe("Channel for moderation/audit logs."),
           tickets: z.string().nullable().default(null).describe("Channel for the ticket panel / where tickets are created."),
           memberLog: z.string().nullable().default(null).describe("Channel for join/leave / new-member notices."),
           liveNotify: z.string().nullable().default(null).describe("Channel for streamer LIVE notifications."),
         })
-          .describe("System channel IDs (or '#name'/'@id' selectors).")
+          .describe("System channel IDs (or '#id'/'@name' selectors).")
           .default({ modLog: null, tickets: null, memberLog: null, liveNotify: null }),
         punishments: z.object({
           enabled: z.boolean().default(true).describe("Whether the punishment/offense system is enabled."),

--- a/src/controllers/discord/interfaces/config.d.ts
+++ b/src/controllers/discord/interfaces/config.d.ts
@@ -14,9 +14,15 @@ declare global {
         mod?: string | null;
         /** Admin role — can use admin tools (edit/entry/rules/set/drbot). */
         admin?: string | null;
+        /**
+         * Streamer role — can use `/schedule` and press its **Partake** button. Either a role ID
+         * prefixed with '#' (e.g. "#123456789") or a role name prefixed with '@' (e.g. "@Streamers").
+         * When unset, the first role whose name looks like "streamer(s)" is used.
+         */
+        streamer?: string | null;
       };
 
-      /** Channel IDs (or '#name'/'@id' selectors) for bot systems. */
+      /** Channel IDs (or '#id'/'@name' selectors) for bot systems. */
       channels?: {
         /** Where moderation/audit actions are logged. */
         modLog?: string | null;
@@ -48,7 +54,7 @@ declare global {
       starboard?: {
         /** Whether the starboard is enabled. @default false */
         enabled?: boolean;
-        /** The starboard channel. Either a channel name prefixed with '#' (e.g. "#starboard") or a channel ID prefixed with '@' (e.g. "@123456789"). If null, a channel with 'starboard' in its name is used. @default null */
+        /** The starboard channel. Either a channel ID prefixed with '#' (e.g. "#123456789") or a channel name prefixed with '@' (e.g. "@starboard"). If null, a channel with 'starboard' in its name is used. @default null */
         channel?: string | null;
         /** The emoji that triggers the starboard. Either a unicode emoji or a custom emoji ID. @default "⭐" */
         emoji?: string;
@@ -102,9 +108,9 @@ declare global {
       birthdays?: {
         /** Whether birthday announcements are enabled. @default true */
         enabled?: boolean;
-        /** The channel to send birthday messages in. Either a channel name prefixed with '#' or a channel ID prefixed with '@'. If null, a channel with 'birthdays' in its name is used. @default null */
+        /** The channel to send birthday messages in. Either a channel ID prefixed with '#' or a channel name prefixed with '@'. If null, a channel with 'birthdays' in its name is used. @default null */
         channel?: string | null;
-        /** The role to give users on their birthday. Either a role name prefixed with '#' or a role ID prefixed with '@'. If null, a role with 'birthday' in its name is used. @default null */
+        /** The role to give users on their birthday. Either a role ID prefixed with '#' or a role name prefixed with '@'. If null, a role with 'birthday' in its name is used. @default null */
         role?: string | null;
       };
     };

--- a/src/controllers/discord/lib/misc.ts
+++ b/src/controllers/discord/lib/misc.ts
@@ -100,8 +100,8 @@ export async function getAllBirthdays(): Promise<BirthdayEntry[]> {
 
 /**
  * Resolves a configured channel selector to a text channel.
- * - `#name` selects by exact channel name
- * - `@id` selects by channel ID
+ * - `#id` selects by channel ID
+ * - `@name` selects by exact channel name
  * - `null` falls back to the first text channel whose name matches `fallback`
  */
 export async function resolveTextChannel(
@@ -113,10 +113,10 @@ export async function resolveTextChannel(
 
   let channel: Discord.GuildBasedChannel | null | undefined = null;
   if (selector?.startsWith("#")) {
+    channel = channels.get(selector.substring(1));
+  } else if (selector?.startsWith("@")) {
     const name = selector.substring(1);
     channel = channels.find((c) => c?.name === name);
-  } else if (selector?.startsWith("@")) {
-    channel = channels.get(selector.substring(1));
   } else {
     channel = channels.find((c) => !!c && fallback.test(c.name) && c.type === Discord.ChannelType.GuildText);
   }
@@ -129,8 +129,8 @@ export async function resolveTextChannel(
 
 /**
  * Resolves a configured role selector to a role.
- * - `#name` selects by exact role name
- * - `@id` selects by role ID
+ * - `#id` selects by role ID
+ * - `@name` selects by exact role name
  * - `null` falls back to the first role whose name matches `fallback`
  */
 export async function resolveRole(
@@ -141,10 +141,10 @@ export async function resolveRole(
   const roles = await guild.roles.fetch();
 
   if (selector?.startsWith("#")) {
+    return roles.get(selector.substring(1)) ?? null;
+  } else if (selector?.startsWith("@")) {
     const name = selector.substring(1);
     return roles.find((r) => r.name === name) ?? null;
-  } else if (selector?.startsWith("@")) {
-    return roles.get(selector.substring(1)) ?? null;
   }
 
   return roles.find((r) => fallback.test(r.name)) ?? null;

--- a/src/controllers/discord/schedule.tables.ts
+++ b/src/controllers/discord/schedule.tables.ts
@@ -1,0 +1,51 @@
+import TableDefinition from "@/lib/base/tableDefinition";
+
+/**
+ * SurrealDB table backing `/schedule` — the co-stream announcement posts created by the Streamers
+ * role in Discord.
+ *
+ * One row per posted announcement, keyed by the announcement message so the button handler can find
+ * it from the interaction alone. `partakers` holds the streamers who pressed **Partake**, each with
+ * the Twitch schedule segment id that was created for them, so **Withdraw** can delete exactly that
+ * segment again.
+ *
+ * SCHEMALESS + OVERWRITE so it can be (re)applied idempotently on startup, matching `tables.ts`.
+ * The filename ends in `tables.ts` so the SDB controller auto-loads it.
+ */
+export default class DiscordScheduleDefinitions extends TableDefinition {
+  public static override priority = 2; //? After the core discord tables (priority 1)
+
+  public static readonly DISCORD_SCHEDULED_STREAMS = `
+    DEFINE TABLE OVERWRITE discord_scheduled_streams SCHEMALESS;
+
+    -- Where the announcement embed lives. message_id is the lookup key used by the button handler.
+    DEFINE FIELD OVERWRITE message_id ON discord_scheduled_streams TYPE string;
+    DEFINE FIELD OVERWRITE channel_id ON discord_scheduled_streams TYPE string;
+    DEFINE FIELD OVERWRITE guild_id ON discord_scheduled_streams TYPE string;
+
+    -- The Discord user who ran /schedule.
+    DEFINE FIELD OVERWRITE created_by ON discord_scheduled_streams TYPE string;
+
+    DEFINE FIELD OVERWRITE title ON discord_scheduled_streams TYPE string;
+    DEFINE FIELD OVERWRITE description ON discord_scheduled_streams TYPE string | none DEFAULT none;
+
+    -- Twitch category. game_id is what gets sent to Helix when a segment is created.
+    DEFINE FIELD OVERWRITE game_id ON discord_scheduled_streams TYPE string;
+    DEFINE FIELD OVERWRITE game_name ON discord_scheduled_streams TYPE string;
+
+    -- Poster shown on the embed: either the uploaded attachment's URL or the game's box art.
+    DEFINE FIELD OVERWRITE poster_url ON discord_scheduled_streams TYPE string | none DEFAULT none;
+
+    DEFINE FIELD OVERWRITE start_time ON discord_scheduled_streams TYPE datetime;
+    DEFINE FIELD OVERWRITE end_time ON discord_scheduled_streams TYPE datetime | none DEFAULT none;
+    -- Segment length in minutes (Twitch requires 30–1380); derived from end_time when one was given.
+    DEFINE FIELD OVERWRITE duration ON discord_scheduled_streams TYPE number;
+    -- IANA timezone the times were entered in, forwarded to Twitch with each segment.
+    DEFINE FIELD OVERWRITE timezone ON discord_scheduled_streams TYPE string DEFAULT 'UTC';
+
+    -- [{ discord_id, twitch_id, display_name, segment_id }] — one entry per streamer who partook.
+    DEFINE FIELD OVERWRITE partakers ON discord_scheduled_streams TYPE array DEFAULT [];
+
+    DEFINE INDEX OVERWRITE unique_scheduled_stream_message ON discord_scheduled_streams FIELDS message_id UNIQUE;
+  `.trim();
+}

--- a/src/controllers/manager/client.ts
+++ b/src/controllers/manager/client.ts
@@ -211,10 +211,12 @@ export default class ManagerClient {
     delay: { keyboard: number; mouse: number };
     ice: { enabled: boolean; friction: number; strength: number };
     drift: { enabled: boolean; speed: number; angleDeg: number };
-  } = { enabled: false, disabled: [], redirects: [], mouse: null, delay: { keyboard: 0, mouse: 0 }, ice: { enabled: false, friction: 0.85, strength: 0.5 }, drift: { enabled: false, speed: 120, angleDeg: 90 } };
+    sensitivity: { enabled: boolean; scaleX: number; scaleY: number };
+    typos: { enabled: boolean; chance: number };
+  } = { enabled: false, disabled: [], redirects: [], mouse: null, delay: { keyboard: 0, mouse: 0 }, ice: { enabled: false, friction: 0.85, strength: 0.5 }, drift: { enabled: false, speed: 120, angleDeg: 90 }, sensitivity: { enabled: false, scaleX: 1, scaleY: 1 }, typos: { enabled: false, chance: 0.1 } };
 
   public resetInterceptionState() {
-    this.interceptionState = { enabled: false, disabled: [], redirects: [], mouse: null, delay: { keyboard: 0, mouse: 0 }, ice: { enabled: false, friction: 0.85, strength: 0.5 }, drift: { enabled: false, speed: 120, angleDeg: 90 } };
+    this.interceptionState = { enabled: false, disabled: [], redirects: [], mouse: null, delay: { keyboard: 0, mouse: 0 }, ice: { enabled: false, friction: 0.85, strength: 0.5 }, drift: { enabled: false, speed: 120, angleDeg: 90 }, sensitivity: { enabled: false, scaleX: 1, scaleY: 1 }, typos: { enabled: false, chance: 0.1 } };
   }
 
   // ── Screen-block overlay ─────────────────────────────────────────────────────
@@ -369,6 +371,28 @@ export default class ManagerClient {
     };
     this.interceptionState.drift = state;
     return this.request<{ enabled: boolean; speed: number; angleDeg: number }>("interception.drift.set", state);
+  }
+
+  // ── Mouse sensitivity (delta multiplier; per-axis, clamped [0.05, 20] client-side) ──
+  public interceptionSensitivitySet(opts: { enabled?: boolean; scaleX?: number; scaleY?: number }) {
+    const num = (v: unknown, d: number) => (Number.isFinite(v as number) ? Number(v) : d);
+    const state = {
+      enabled: opts.enabled === true,
+      scaleX: num(opts.scaleX, 1),
+      scaleY: num(opts.scaleY, 1),
+    };
+    this.interceptionState.sensitivity = state;
+    return this.request<{ enabled: boolean }>("interception.sensitivity.set", state);
+  }
+
+  // ── Keyboard typos (chance 0..1 of hitting a physically adjacent key) ────────
+  public interceptionTyposSet(opts: { enabled?: boolean; chance?: number }) {
+    const state = {
+      enabled: opts.enabled === true,
+      chance: Number.isFinite(opts.chance as number) ? Number(opts.chance) : 0.1,
+    };
+    this.interceptionState.typos = state;
+    return this.request<{ enabled: boolean }>("interception.typos.set", state);
   }
 
   // ── Input delay (artificial lag; seconds, float) ─────────────────────────────

--- a/src/controllers/twitch/client.ts
+++ b/src/controllers/twitch/client.ts
@@ -1128,6 +1128,8 @@ export default class TwitchClient {
   public getStreams = this.bindChannelFn(User.getStreams)
   /** Get information about a game. */
   public getGame = this.bindChannelFn(User.getGame)
+  /** Search Twitch's categories/games by (partial) name. */
+  public searchCategories = this.bindChannelFn(User.searchCategories)
   /** Find or get information about a VoD. */
   public getVideos = this.bindChannelFn(User.getVideos)
 
@@ -1148,6 +1150,10 @@ export default class TwitchClient {
 
   /** Get the authenticated broadcaster's stream schedule. Returns null when no schedule exists. */
   public getStreamSchedule = this.bindChannelFn(Schedule.getStreamSchedule)
+  /** Add a segment to the authenticated broadcaster's schedule. Requires "channel:manage:schedule". */
+  public createScheduleSegment = this.bindChannelFn(Schedule.createScheduleSegment)
+  /** Remove a segment from the authenticated broadcaster's schedule. Requires "channel:manage:schedule". */
+  public deleteScheduleSegment = this.bindChannelFn(Schedule.deleteScheduleSegment)
 
 
   public fetchUser = async (idLogin?: string): Promise<TwitchUser | null> => {

--- a/src/controllers/twitch/funcs/schedule.ts
+++ b/src/controllers/twitch/funcs/schedule.ts
@@ -1,5 +1,9 @@
 import TwitchClient from "@twitch/client";
 
+/** Twitch's hard bounds for a schedule segment's duration, in minutes. */
+export const SEGMENT_MIN_DURATION = 30;
+export const SEGMENT_MAX_DURATION = 1380;
+
 export type ScheduleSegment = {
   id: string;
   start_time: string;
@@ -53,5 +57,86 @@ export async function getStreamSchedule(this: TwitchClient): Promise<StreamSched
     }
     this.logger.warn("Failed to fetch stream schedule:", err?.response?.data?.message || err?.message || err);
     return null;
+  }
+}
+
+export type NewScheduleSegment = {
+  /** When the stream starts. */
+  startTime: Date;
+  /** IANA timezone the segment is expressed in (e.g. "Europe/Stockholm"). */
+  timezone: string;
+  /** Length of the stream in minutes. Twitch only accepts 30–1380. */
+  durationMinutes: number;
+  /** Twitch category/game id, if the stream has one. */
+  categoryId?: string | null;
+  /** Stream title (Twitch caps this at 140 characters). */
+  title?: string | null;
+  /** Whether the segment repeats weekly. @default false */
+  isRecurring?: boolean;
+};
+
+/**
+ * Add a one-off (or recurring) segment to the authenticated broadcaster's schedule
+ * (`POST /schedule/segment?broadcaster_id=...`). Requires the `channel:manage:schedule` scope.
+ *
+ * Twitch answers with the broadcaster's schedule containing only the newly created segment, so the
+ * created segment is unwrapped and returned. Throws on failure with Twitch's own error message so
+ * callers can surface it verbatim.
+ */
+export async function createScheduleSegment(
+  this: TwitchClient,
+  segment: NewScheduleSegment,
+): Promise<ScheduleSegment> {
+  const duration = Math.round(segment.durationMinutes);
+  if (duration < SEGMENT_MIN_DURATION || duration > SEGMENT_MAX_DURATION) {
+    throw new Error(
+      `A stream's scheduled duration must be between ${SEGMENT_MIN_DURATION} and ${SEGMENT_MAX_DURATION} minutes (got ${duration}).`,
+    );
+  }
+
+  const body: Record<string, any> = {
+    //? Helix wants RFC3339. Trimming the milliseconds keeps it byte-identical to Twitch's examples.
+    start_time: segment.startTime.toISOString().replace(/\.\d{3}Z$/, "Z"),
+    timezone: segment.timezone,
+    duration: String(duration),
+    is_recurring: segment.isRecurring ?? false,
+  };
+  if (segment.categoryId) body.category_id = segment.categoryId;
+  if (segment.title) body.title = segment.title.slice(0, 140);
+
+  try {
+    const res = await this.api.post(`/schedule/segment`, body, {
+      params: { broadcaster_id: this.IAM.id },
+    });
+
+    const created = (res?.data?.data as StreamSchedule | undefined)?.segments?.[0];
+    if (!created) throw new Error("Twitch accepted the segment but returned no segment data.");
+    return created;
+  } catch (err: any) {
+    const message = err?.response?.data?.message || err?.message || String(err);
+    this.logger.warn("Failed to create schedule segment:", message);
+    throw new Error(message);
+  }
+}
+
+/**
+ * Remove a segment from the authenticated broadcaster's schedule
+ * (`DELETE /schedule/segment?broadcaster_id=...&id=...`). Requires `channel:manage:schedule`.
+ *
+ * A segment that no longer exists (404) counts as success — the caller's intent is "it's gone".
+ */
+export async function deleteScheduleSegment(this: TwitchClient, segmentId: string): Promise<boolean> {
+  try {
+    await this.api.delete(`/schedule/segment`, {
+      params: { broadcaster_id: this.IAM.id, id: segmentId },
+    });
+    return true;
+  } catch (err: any) {
+    if (err?.response?.status === 404) return true;
+    this.logger.warn(
+      "Failed to delete schedule segment:",
+      err?.response?.data?.message || err?.message || err,
+    );
+    return false;
   }
 }

--- a/src/controllers/twitch/funcs/user.ts
+++ b/src/controllers/twitch/funcs/user.ts
@@ -35,6 +35,42 @@ export async function getGame(this: TwitchClient, idOrName: string) {
     .then(ResDataData0);
 }
 
+export type TwitchCategory = {
+  id: string;
+  name: string;
+  /** Box art URL with `{width}`/`{height}` placeholders still in it. */
+  box_art_url: string;
+};
+
+/**
+ * Search Twitch's categories/games by (partial) name — `GET /search/categories?query=...`.
+ *
+ * This is the endpoint that backs the category picker on Twitch itself, so it does prefix/fuzzy
+ * matching where `getGame()` requires an exact name. Returns `[]` on any failure so callers (e.g.
+ * Discord autocomplete, which cannot report an error) can just render an empty list.
+ */
+export async function searchCategories(
+  this: TwitchClient,
+  query: string,
+  limit = 25,
+): Promise<TwitchCategory[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  try {
+    const res = await this.api.get(`/search/categories`, {
+      params: { query: trimmed, first: Math.min(Math.max(limit, 1), 100) },
+    });
+    return (res?.data?.data as TwitchCategory[] | undefined) ?? [];
+  } catch (err: any) {
+    this.logger.warn(
+      "Failed to search Twitch categories:",
+      err?.response?.data?.message || err?.message || err,
+    );
+    return [];
+  }
+}
+
 export async function getVideos(this: TwitchClient, settings: any): Promise<{
   id: string;
   stream_id: string;


### PR DESCRIPTION
## `/schedule`

A Streamers-role member announces a co-stream (Twitch category via live Helix autocomplete, title, start / optional end, poster, description). Others press **Partake** to add it to their own Twitch schedule; **Withdraw** deletes exactly the segment created for them. State lives in `discord_scheduled_streams` keyed by the announcement message, so buttons survive restarts.

Times parse in the invoker's `/settimezone` timezone — absolute dates, bare times (`23:30`) and durations (`3h30m`) all verified, including next-day rollover.

Two non-obvious bits:
- The poster is **re-uploaded** onto the announcement rather than linked. Interaction attachment URLs are signed and expire within a day, so the embed is rebuilt from the message's own freshly-signed URL.
- Button presses are acknowledged **before** queueing (Discord invalidates an unanswered interaction after 3s) and serialized per-announcement so simultaneous partakes can't clobber the partakers array.

## `/link` (owner-only)

Ties a Twitch account to a Discord account on one Waiter user, creating `discord_users`/`twitch_users` rows as needed.

Worth knowing: **nothing previously wrote `users.discord`.** The field and its unique index existed, but no code path populated them — so every Discord member was unlinked and `/schedule`'s Partake could never resolve a client. This is what makes that path reachable.

Where the two halves already belong to different Waiter users it merges via `mergeFromTo` (keeping the Twitch side, which owns `streamer_tokens`), since `users.twitch` and `users.discord` are both UNIQUE and cross-linking would otherwise fail on the index.

## Trigger cloning

Clone a custom redemption trigger to another channel — new managed reward on the target from the stored `reward_config`, plus its own trigger row; source untouched.

Restricted to **managed** rewards: a `mode:"existing"` trigger points at a reward id that only exists on the source channel, so copying it would produce a row that looks correct in the UI and silently never fires. Actions re-bind by name against the target, falling back to the source's compiled snapshot.

Permissions mirror what it composes rather than inventing a rule — source needs `GET /api/triggers` access, target needs `POST /api/triggers` access.

## Also

- `interceptionSensitivitySet` / `interceptionTyposSet` + dashboard API cases, for the new wmgr effects.
- Twitch: `createScheduleSegment`, `deleteScheduleSegment`, `searchCategories`.
- Reverses the `resolveRole`/`resolveTextChannel` selector convention to `#` = ID, `@` = name. **Verified against the production config**, which sets no `channels`/`roles`/`starboard`/`birthdays` keys — those calls fall through to the unchanged regex fallback, so no deployed selector is affected.

## Testing

Typecheck clean (root + dashboard). Deployed and running on prod — all controllers healthy, 16 guild commands registered. But `/schedule`, `/link` and the clone button have **not been executed**; `/link` and clone both mutate real data (`mergeFromTo` deletes a `users` row; clone creates real Twitch rewards), so first runs deserve care.

`.env.schema` is deliberately **not** included — the working copy has the DEVELOPMENT credential block active, and committing it would point production at the dev bot.

https://claude.ai/code/session_01Vwcb9Z6oJ1scZpJsD2Q4qQ